### PR TITLE
Free up disk space for crossbuild jobs

### DIFF
--- a/.github/workflows/step_build.yml
+++ b/.github/workflows/step_build.yml
@@ -22,6 +22,20 @@ jobs:
           make promu
           go mod download
 
+      # This is intended to address disk space issues that have surfaced
+      # intermittently during CI -
+      # https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+      # https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
+      - name: Free up space in /dev/root
+        run: |
+            echo "Disk usage before clean up:"
+            df -h
+            sudo rm -rf /usr/share/dotnet
+            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+            sudo rm -rf /opt/hostedtoolcache
+            echo "Disk usage after clean up:"
+            df -h
+
       # Cross compile for only AMD and ARM archs in CI to reduce CI time and artifacts size
       # We will compile for all supported archs in release workflow
       - name: Cross compile Go packages

--- a/.github/workflows/step_cross-build.yml
+++ b/.github/workflows/step_cross-build.yml
@@ -22,6 +22,20 @@ jobs:
           make promu
           go mod download
 
+      # This is intended to address disk space issues that have surfaced
+      # intermittently during CI -
+      # https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+      # https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
+      - name: Free up space in /dev/root
+        run: |
+            echo "Disk usage before clean up:"
+            df -h
+            sudo rm -rf /usr/share/dotnet
+            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+            sudo rm -rf /opt/hostedtoolcache
+            echo "Disk usage after clean up:"
+            df -h
+
       # These steps are taken from https://circleci.com/developer/orbs/orb/prometheus/prometheus#jobs-publish_release
       - name: Setup build environment
         run: |


### PR DESCRIPTION
* As CEEMS apps grew in size due to k8s dependencies, concurrent cross build job failed due to lack of disk space. This PR attempts to free up unnecessary disk space before cross building binaries.

Ref: https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930