### PR TITLE
Fix parsing nvidia-smi XML output

### DIFF
--- a/pkg/collector/libvirt.go
+++ b/pkg/collector/libvirt.go
@@ -200,15 +200,21 @@ func NewLibvirtCollector(logger *slog.Logger) (Collector, error) {
 		return nil, err
 	}
 
-	// Instantiate a new instance of gpuSMI struct
+	// Instantiate a new instance of GPUSMI struct
 	gpuSMI, err := NewGPUSMI(client, logger)
 	if err != nil {
 		logger.Error("Error creating GPU SMI instance", "err", err)
+
+		return nil, err
 	}
 
 	// Attempt to get GPU devices
 	if err := gpuSMI.Discover(); err != nil {
+		// If we failed to fetch GPUs that are from supported
+		// vendor, return with error
 		logger.Error("Error fetching GPU devices", "err", err)
+
+		return nil, err
 	}
 
 	// Check if vGPU is activated on atleast one GPU
@@ -254,7 +260,7 @@ func NewLibvirtCollector(logger *slog.Logger) (Collector, error) {
 		hostname:                      hostname,
 		gpuSMI:                        gpuSMI,
 		vGPUActivated:                 vGPUActivated,
-		instanceDevicesCacheTTL:       3 * time.Hour,
+		instanceDevicesCacheTTL:       15 * time.Minute,
 		instanceDeviceslastUpdateTime: time.Now(),
 		securityContexts:              map[string]*security.SecurityContext{libvirtReadXMLCtx: securityCtx},
 		instanceGpuFlag: prometheus.NewDesc(

--- a/pkg/collector/testdata/nvidia-smi
+++ b/pkg/collector/testdata/nvidia-smi
@@ -59,6 +59,16 @@ sub_--query(){
                         <virtualization_mode>VGPU</virtualization_mode>
                         <host_vgpu_mode>N/A</host_vgpu_mode>
                 </gpu_virtualization_mode>
+                <processes>
+                        <process_info>
+                                <gpu_instance_id>N/A</gpu_instance_id>
+                                <compute_instance_id>N/A</compute_instance_id>
+                                <pid>239709</pid>
+                                <type>C</type>
+                                <process_name>./gpu_burn</process_name>
+                                <used_memory>72776 MiB</used_memory>
+                        </process_info>
+                </processes>
         </gpu>
         <gpu id=\"00000000:15:00.0\">
                 <product_name>NVIDIA A100-PCIE-40GB</product_name>
@@ -213,6 +223,16 @@ sub_--query(){
                         <virtualization_mode>VGPU</virtualization_mode>
                         <host_vgpu_mode>N/A</host_vgpu_mode>
                 </gpu_virtualization_mode>
+                <processes>
+                        <process_info>
+                                <gpu_instance_id>5</gpu_instance_id>
+                                <compute_instance_id>0</compute_instance_id>
+                                <pid>239709</pid>
+                                <type>C</type>
+                                <process_name>./gpu_burn</process_name>
+                                <used_memory>7276 MiB</used_memory>
+                        </process_info>
+                </processes>
         </gpu>
 
         <gpu id=\"00000000:81:00.0\">


### PR DESCRIPTION
* Fix unmarshaling XML output of nvidia-smi command by always assuming the values to be strings and then converting them to uint64 in custom unmarshaler.

* Any errors in instantiation of gpu smi command or detection of GPUs should stop collector instantitation and return error. If not exporter will silently ignore the errors and starts exporting metrics without GPU related ones

* For SLURM collector, track the jobIDs that do not have GPUs associated. If there is at least one job without GPU, we attempt to get the GPU index of the job in the next scrape. If not, we will loose the GPU association of that job for entire job period which is not desirable. The side effect is that if a job really do not have GPUs allocated, it will make exporter to find GPU associations for every scrape. However, it is better to not lose data rather then be more efficient and lose data.

* For k8s and libvirt, use a cache with TTL to re-associate pods/VMs to GPU association. Use a TTL of 15min to be more frequent and not lose much data.